### PR TITLE
Fix Viasat Krugersdorp location. Website typo.

### DIFF
--- a/data/groundstations/viasat.json
+++ b/data/groundstations/viasat.json
@@ -97,7 +97,7 @@
         "type": "Point",
         "coordinates": [
           27.70,
-          25.88
+          -25.88
         ]
       },
       "properties": {


### PR DESCRIPTION
The Viasat webpage of antenna locations lists Krugersdorp, South Africa as a northern latitude when in reality is it not. This fixes it.

Addresses Issue: https://github.com/duncaneddy/ground-station-optimizer/issues/1